### PR TITLE
Fix `IndexError: index 2 is out of bounds for axis 0 with size 2`

### DIFF
--- a/src/pc.py
+++ b/src/pc.py
@@ -89,8 +89,9 @@ def extend_cpdag(G, O):
             all_k = [k for k in range(n_nodes) if (g[j][k] == 1 and g[k][j] == 1) and (g[i][k] == 0 and g[k][i] == 0)]
 
             if len(all_k) > 0:
-                g[j][all_k] = 1
-                g[all_k][j] = 0
+                for k in all_k:
+                    g[j][k] = 1
+                    g[k][j] = 0
 
         return g
 


### PR DESCRIPTION
## Fix

用下边的代码生成数据，然后运行`run.py`会报`IndexError: index 2 is out of bounds for axis 0 with size 2`，这里进行修复。

```python
import csv

from scipy.stats import norm

def Residual():
    while True:
        yield norm.rvs(0, 1)

def GenerateData():
    # Variables: X1, X2, X3, X4, X5, X6
    # Relationships: (X1 + X2) -> X3
    #                X3 -> X4
    #                X3 -> X5
    #                (X4 + X5) -> X6

    X1 = norm.rvs(5, 3, 10000)
    X2 = norm.rvs(10, 4, 10000)
    X3 = [x1 + x2 + r for x1, x2, r in zip(X1, X2, Residual())]
    X4 = [2 * x3 + r for x3, r in zip(X3, Residual())]
    X5 = [3 * x3 + r for x3, r in zip(X3, Residual())]
    X6 = [4 * x4 + 2 * x5 + r for x4, x5, r in zip(X4, X5, Residual())]
    return [
        {'X1': x1, 'X2': x2, 'X3': x3, 'X4': x4, 'X5': x5, 'X6': x6}
        for x1, x2, x3, x4, x5, x6 in zip(X1, X2, X3, X4, X5, X6)
    ]

if __name__ == '__main__':
    with open('data/test.csv', 'w', newline='') as f:
        writer = csv.DictWriter(f, fieldnames=['X1', 'X2', 'X3', 'X4', 'X5', 'X6'])
        writer.writeheader()
        writer.writerows(GenerateData())
```